### PR TITLE
fix: remove irrelevant instructions from the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,3 @@ RUN yum update -y \
     && cargo install cargo-watch \
     && cargo install rustfmt-nightly \
     && yum clean all
-
-COPY . /usr/src/api-keys
-WORKDIR /usr/src/api-keys
-
-VOLUME ["/usr/src/api-keys"]
-
-ENTRYPOINT ["scripts/entry.sh"]


### PR DESCRIPTION
The `COPY`, `VOLUME`, and `WORKDIR` instructions are better suited for downstream usage.