### PR TITLE
fix: openssl-dev should be openssl-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux
 ENV PATH /root/.cargo/bin:$PATH
 
 RUN yum update -y \
-    && yum install -y gcc g++ git make openssl-dev \
+    && yum install -y gcc g++ git make openssl-devel \
     && curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain nightly \
     && cargo install cargo-make \
     && cargo install cargo-watch \


### PR DESCRIPTION
Fixes a bug where openssl dependent crates do not compile.