### PR TITLE
refactor: use the same cargo and rustup home as the offical rust image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM amazonlinux
 
-ENV PATH /root/.cargo/bin:$PATH
+ENV PATH=/usr/local/cargo/bin:$PATH \
+    CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup
 
 RUN yum update -y \
     && yum install -y gcc g++ git make openssl-devel \
-    && curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain nightly \
+    && curl https://sh.rustup.rs -sSf | sh -s -- \
+        --default-toolchain nightly \
+        --no-modify-path \
+        -y \
     && cargo install cargo-make \
     && cargo install cargo-watch \
+    && cargo install clippy \
     && cargo install rustfmt-nightly \
     && yum clean all


### PR DESCRIPTION
This helps bring the environment closer to the [official rust docker image](https://github.com/rust-lang-nursery/docker-rust).